### PR TITLE
Add support to run server via docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ruby:2.7.1-alpine3.12
+
+RUN apk add --no-cache g++ make
+RUN gem install carthage_remote_cache
+
+EXPOSE 9292
+CMD ["carthagerc", "server"]

--- a/README.md
+++ b/README.md
@@ -205,6 +205,30 @@ If you want to stop the agent, run:
 
 Check out official documentation on [Launch Agents](https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html) for more info.
 
+#### Docker
+
+To build an image based on the latest released gem, run
+
+    $ docker build -t carthagerc .
+
+Afterwards you can run the image in a container using
+
+    $ docker run -d --publish 9292:9292 --name carthagerc carthagerc:latest
+
+The server will now be available on port 9292 on `localhost`. Note that the command above will cause any data added to `~/.carthagerc_server` to be written into the container layer. While this works, it's generally discouraged due to decreased performance and portability. To avoid this, you can use a volume.
+
+    $ docker run -d --publish 9292:9292 --mount "source=carthagerc,target=/root/.carthagerc_server" --name carthagerc carthagerc:latest
+
+We also recommend adding the `--log-opt` option to limit the size of logs, e.g. `--log-opt max-size=50m`.
+
+To inspect the logs after running, use
+
+    $ docker logs carthagerc
+
+To stop the container, run
+
+    $ docker container stop carthagerc
+
 ### Version
 
     $ carthagerc version


### PR DESCRIPTION
@juraj-blahunka curious to hear what you think of this. Running this via docker would do away with any Ruby setup trouble on our in-house VMs. Docker also has an option to automatically rotate the logs without restarting the container.

Getting this to work was relatively easy and only required minimal changes. My limited Ruby-fu didn't allow me to fully understand the magic in the gemspec file though. If we could decouple that file from the source code itself, the image creation would be more efficient. It shouldn't really make a huge difference though as we're probably not planning to run the server via docker during development so image rebuilding should be a rare action.

The image size currently is around 300 megabytes. We probably could get it down some more by using a multi-stage build and only copying the relevant folders over (neglecting anything that was only needed for building). I didn't investigate that yet though since the size seemed ok-ish for our needs.