### PR TITLE
Retry on network errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Documentation is also available when running `carthagerc` or `carthagerc --help`
         -f, --force                      Force upload/download of framework archives even if local and server .version files match
         -h, --help                       Show help
         -m, --platform=PLATFORM          Comma delimited list of platforms which should be downloaded from the server; e.g. `--platform iOS,macOS`; Supported values: iOS, macOS, tvOS, watchOS
+        -n, --no-retry                   Don't retry download or upload on network failures
         -p, --port=PORT                  Server application port used when starting server, default port is 9292
         -v, --verbose                    Show extra runtime information
 

--- a/bin/carthagerc
+++ b/bin/carthagerc
@@ -10,6 +10,7 @@ ARGV << "-h" if ARGV.empty?
 command = ARGV[0]
 options = {
   :force => false,
+  :is_retry_enabled => true,
   :server_port => SERVER_DEFAULT_PORT,
   :verbose => false,
 }
@@ -63,6 +64,10 @@ opt_parser = OptionParser.new do |opt|
   opt.on("-m", "--platform=PLATFORM", "Comma delimited list of platforms which should be downloaded from the server; e.g. `--platform iOS,macOS`; Supported values: #{PLATFORMS.map(&:to_s).join(", ")}") do |platform|
     raise AppError.new("[-p|--platform] is only supported for the 'download' command") if command != "download"
     options[:platforms] = platform_to_symbols(platform)
+  end
+
+  opt.on("-n", "--no-retry", "Don't retry download or upload on network failures") do
+    options[:is_retry_enabled] = false
   end
 
   opt.on("-pPORT", "--port=PORT", "Server application port used when starting server, default port is #{SERVER_DEFAULT_PORT}") do |port|

--- a/lib/commands/download_command.rb
+++ b/lib/commands/download_command.rb
@@ -4,7 +4,7 @@ class DownloadCommand
   def self.new_with_defaults(options)
     shell = ShellWrapper.new
     config = Configuration.new(shell)
-    networking = Networking.new(config)
+    networking = Networking.new(config, options[:is_retry_enabled])
     api = API.new(shell, config, networking, options)
 
     DownloadCommand.new(

--- a/lib/commands/upload_command.rb
+++ b/lib/commands/upload_command.rb
@@ -4,7 +4,7 @@ class UploadCommand
   def self.new_with_defaults(options)
     shell = ShellWrapper.new
     config = Configuration.new(shell)
-    networking = Networking.new(config)
+    networking = Networking.new(config, options[:is_retry_enabled])
     api = API.new(shell, config, networking, options)
 
     UploadCommand.new(

--- a/lib/commands/verify_command.rb
+++ b/lib/commands/verify_command.rb
@@ -2,7 +2,7 @@ class VerifyCommand
   def self.new_with_defaults(options)
     shell = ShellWrapper.new
     config = Configuration.new(shell)
-    networking = Networking.new(config)
+    networking = Networking.new(config, options[:is_retry_enabled])
     api = API.new(shell, config, networking, options)
 
     VerifyCommand.new(api: api)

--- a/lib/networking.rb
+++ b/lib/networking.rb
@@ -11,11 +11,13 @@ class Networking
   def get_server_version
     url = new_version_url
     $LOG.debug("Fetching server version from #{url}")
-    server_version = RestClient.get(url) do |response, request, result|
-      if response.code == 200
-        response.strip
-      else
-        raise AppError.new, "Failed to read server version from #{url}, response:\n  #{response[0...300]}"
+    server_version = with_retry do
+      RestClient.get(url) do |response, request, result|
+        if response.code == 200
+          response.strip
+        else
+          raise AppError.new, "Failed to read server version from #{url}, response:\n  #{response[0...300]}"
+        end
       end
     end
     server_version
@@ -31,13 +33,15 @@ class Networking
       params[:platform] = platforms.map(&:to_s).join(",")
     end
 
-    $LOG.debug("Downloading version file from #{url}, params: #{params}")
-    version_file = RestClient.get(url, { params: params }) do |response, request, result|
-      if response.code == 200
-        File.write(carthage_dependency.version_filename, response.to_s)
-        VersionFile.new(carthage_dependency.version_filename)
-      else
-        nil
+    version_file = with_retry do
+      $LOG.debug("Downloading version file from #{url}, params: #{params}")
+      RestClient.get(url, { params: params }) do |response, request, result|
+        if response.code == 200
+          File.write(carthage_dependency.version_filename, response.to_s)
+          VersionFile.new(carthage_dependency.version_filename)
+        else
+          nil
+        end
       end
     end
     version_file
@@ -46,10 +50,12 @@ class Networking
   # @raise AppError on upload failure
   def upload_version_file(carthage_dependency)
     url = new_version_file_url(carthage_dependency)
-    $LOG.debug("Uploading #{carthage_dependency.version_filename}")
-    RestClient.post(url, :version_file => File.new(carthage_dependency.version_filepath)) do |response, request, result|
-      unless response.code == 200
-        raise AppError.new, "Version file upload #{carthage_dependency.version_filename} failed, response:\n  #{response[0..300]}"
+    with_retry do
+      $LOG.debug("Uploading #{carthage_dependency.version_filename}")
+      RestClient.post(url, :version_file => File.new(carthage_dependency.version_filepath)) do |response, request, result|
+        unless response.code == 200
+          raise AppError.new, "Version file upload #{carthage_dependency.version_filename} failed, response:\n  #{response[0..300]}"
+        end
       end
     end
   end
@@ -59,14 +65,16 @@ class Networking
   # @return Hash with CarthageArchive and checksum or nil
   def download_framework_archive(carthage_dependency, framework_name, platform)
     url = new_framework_url(carthage_dependency, framework_name, platform)
-    $LOG.debug("Downloading framework from #{url}")
-    archive = RestClient.get(url) do |response, request, result|
-      if response.code == 200
-        archive = CarthageArchive.new(framework_name, platform)
-        File.write(archive.archive_path, response.to_s)
-        { :archive => archive, :checksum => response.headers[ARCHIVE_CHECKSUM_HEADER_REST_CLIENT] }
-      else
-        nil
+    archive = with_retry do
+      $LOG.debug("Downloading framework from #{url}")
+      RestClient.get(url) do |response, request, result|
+        if response.code == 200
+          archive = CarthageArchive.new(framework_name, platform)
+          File.write(archive.archive_path, response.to_s)
+          { :archive => archive, :checksum => response.headers[ARCHIVE_CHECKSUM_HEADER_REST_CLIENT] }
+        else
+          nil
+        end
       end
     end
     archive
@@ -77,10 +85,12 @@ class Networking
     url = new_framework_url(carthage_dependency, framework_name, platform)
     params = { :framework_file => File.new(zipfile_name) }
     headers = { ARCHIVE_CHECKSUM_HEADER_REST_CLIENT => checksum }
-    $LOG.debug("Uploading framework to #{url}, headers: #{headers}")
-    RestClient.post(url, params, headers) do |response, request, result|
-      unless response.code == 200
-        raise AppError.new, "Framework upload #{zipfile_name} failed, response:\n  #{response[0..300]}"
+    with_retry do
+      $LOG.debug("Uploading framework to #{url}, headers: #{headers}")
+      RestClient.post(url, params, headers) do |response, request, result|
+        unless response.code == 200
+          raise AppError.new, "Framework upload #{zipfile_name} failed, response:\n  #{response[0..300]}"
+        end
       end
     end
   end
@@ -128,5 +138,25 @@ class Networking
   # Mangle identifiers for URL paths.
   def sanitized(input)
     input.gsub(/\//, "_")
+  end
+
+  def with_retry
+    retries_remaining = 3
+    sleep_time_seconds = 5
+    begin
+      result = yield
+    rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError,
+           Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError => e
+      if retries_remaining > 0
+        $LOG.warn("Network request failed - remaining retries: #{retries_remaining}, sleeping for: #{sleep_time_seconds}s, error: #{e.message}")
+        sleep(sleep_time_seconds)
+        retries_remaining -= 1
+        sleep_time_seconds *= 3
+        retry
+      else
+        raise e
+      end
+    end
+    result
   end
 end


### PR DESCRIPTION
The `download` sometimes errors out with 
```
Failed to open TCP connection to example.org:9292 (getaddrinfo: nodename nor servname provided, or not known
```

This may be caused by a temporary DNS issue. The proposed fix is to retry the network operation 3 times with increasing timeouts.